### PR TITLE
stop using deprecated git protocol

### DIFF
--- a/Makefile.inc
+++ b/Makefile.inc
@@ -29,6 +29,6 @@ $(INCLUDE_MAKE):
 cloneLib:
 	@if test -d $(LIB_PATH_BAM_UTIL); \
 	then echo $(LIB_PATH_BAM_UTIL) already exists; \
-	else git clone git://github.com/statgen/libStatGen.git $(LIB_PATH_BAM_UTIL); fi
+	else git clone https://github.com/statgen/libStatGen.git $(LIB_PATH_BAM_UTIL); fi
 	@echo Call make to compile libStatGen and this tool.
 


### PR DESCRIPTION
see https://github.blog/2021-09-01-improving-git-protocol-security-github/ but in a nutshell, `git://` will no longer work for github clones in the next few months. Addresses https://github.com/statgen/bamUtil/issues/67